### PR TITLE
Add Alt Tag for git-commit-and-tree.png Image in Section 4.4

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -52,7 +52,9 @@ $ git commit -m 'Initial commit'</pre><!--</div attr= class="content">--><!--</d
 			<!-- div attr= class="content"-->
 			<figure xml:id="git-commit-tree">
 			<caption>A commit and its tree</caption>
-			<image source='git-commit-and-tree.png'/>
+			<image source='git-commit-and-tree.png'>
+				<description> An illustrative depiction of your Git repository's status following a 'git commit' operation. </description>
+			</image>
 			</figure>
 			<!--</div attr= class="content">-->
 


### PR DESCRIPTION
### Description
Enhanced user experience for individuals using screen readers by adding an alternative description to this image in section 4.4.

### Testing Steps
1. Navigate to section 4.4.
2. Build locally using this branch.
3. Verify the presence of a descriptive alt tag.
-------------------------------------------------------------------------------------------------------------------
![image](https://github.com/pearcej/opensource/assets/97637517/3eae1450-c333-4610-bf8a-aff5db562a19)

fix #210
