### PR TITLE
add description for image git-advance-testing.png in section 4.4.7

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -188,7 +188,9 @@ $ git commit -a -m 'made a change'</pre>
 <!-- div attr= class="content"-->
 <figure xml:id="git-HEAD-moves">
   <caption>The HEAD branch moves forward when a commit is made</caption>
-  <image source='git-advance-testing.png'/>
+    <image source='git-advance-testing.png'>
+  <description> The block representing master head is located at a block representing commit f30ab. </description>
+  </image>
 </figure>
 <!--</div attr= class="content">-->
 

--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -189,7 +189,7 @@ $ git commit -a -m 'made a change'</pre>
 <figure xml:id="git-HEAD-moves">
   <caption>The HEAD branch moves forward when a commit is made</caption>
     <image source='git-advance-testing.png'>
-  <description> The block representing master head is located at a block representing commit f30ab. </description>
+  <description> The block representing master head is located pointing to a block representing commit f30ab. </description>
   </image>
 </figure>
 <!--</div attr= class="content">-->


### PR DESCRIPTION
Did: 
edited source/sec_git_branching.ptx, and added description to image git-advance-testing.png
Test:
-build locally
-Navigate to section 4.4, and find figure 4.4.7.
-Right clone on the page, and inspect
-to the right, an HTML stuff will show up, locate the image and look for the added description


this PR fix #216 