### PR TITLE
Addition of description tag to image "git-head-to-testing.png"

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -166,7 +166,9 @@ f30ab (HEAD -&gt; master, testing) Add feature #32 - ability to add new formats 
 <!-- div attr= class="content"-->
 <figure xml:id="git-HEAD-current-branch">
   <caption>HEAD points to the current branch</caption>
-  <image source='git-head-to-testing.png'/>
+  <image source='git-head-to-testing.png'>
+  	<description>Diagram that shows relation between multiple branches inside a repository</description>
+  </image>
 </figure>
 <!--</div attr= class="content">-->
 


### PR DESCRIPTION
Issue
There was no description tag in the image of tag of "git-head-to-testing.png". That means that if this image fails to be displayed, there will be no indication left to the reader. 

Solution
A description tag is added inside the image tag, which will be rendered by HTML as an alt tag. 

Testing
It is advised to build the project using "pretext build web", then preview the project with the command "preview pretext". There, one should be able to access the Chapter 4.5.4 and do an inspect on the image to see if the alt is present inside the img tag. 

fix #217 