### PR TITLE
Add description tag to 'git-branch-and-history.png'

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -84,7 +84,9 @@ $ git commit -m 'Initial commit'</pre><!--</div attr= class="content">--><!--</d
 <!-- div attr= class="content"-->
 		<figure xml:id="git-branch-and-commit-hostory">
 		<caption>A branch and its commit history</caption>
-		<image source='git-branch-and-history.png'/>
+		<image source='git-branch-and-history.png'>
+			<description> A graph of the commit history of a Git branch. </description>
+		</image>
 		</figure>
 <!--</div attr= class="content">-->
 


### PR DESCRIPTION
fix #242 