### PR TITLE
Add 'history' to Bash Shell Cheat Sheet and Basic Shell Commands

### DIFF
--- a/source/ap_bash_cheat_sheet.ptx
+++ b/source/ap_bash_cheat_sheet.ptx
@@ -185,7 +185,20 @@ The <term>touch</term> command is commonly used for file creation. Its intended 
         </ul>
         </p>
       </li>
-      </dl>
+      <li>
+      <title><c>grep &lt;"string"&gt; &lt;file-name&gt;</c></title>
+      <p>
+        <term>grep</term> is used to search text for patterns specified by the user.
+      <ul>
+        <li>
+          <p>
+          e.g. <c>grep "Hello World!" first_program.txt</c> displays all the lines in the file <c>first_program.txt</c> that contain the text "Hello World!". 
+          </p>
+        </li>
+      </ul>
+    </p>
+    </li>
+    </dl>
     </p>
  </paragraphs>
 
@@ -252,6 +265,25 @@ The <term>touch</term> command is commonly used for file creation. Its intended 
               <p>
               e.g. <c>wc file.txt</c> reports the count of lines, words, and bytes in  file.txt.
               </p>
+            </li>
+            </ul>
+          </p>
+          </li>
+          <li>
+          <title><c>history</c></title>
+          <p>
+            The <term>history</term> command displays a list of previously executed shell commands, allowing users to review their command history.
+          <ul>
+           <li>
+              <p>e.g. <c>history</c> could display:</p>
+                <pre>
+                1  git init
+                2  git add main.c
+                3  git commit -m "Initial commit"
+                4  git remote add origin https://github.com/username/repo.git
+                5  git push -u origin master
+                6  history
+                </pre>
             </li>
           </ul>
         </p>

--- a/source/ap_bash_cheat_sheet.ptx
+++ b/source/ap_bash_cheat_sheet.ptx
@@ -185,19 +185,6 @@ The <term>touch</term> command is commonly used for file creation. Its intended 
         </ul>
         </p>
       </li>
-      <li>
-      <title><c>grep &lt;"string"&gt; &lt;file-name&gt;</c></title>
-      <p>
-        <term>grep</term> is used to search text for patterns specified by the user.
-      <ul>
-        <li>
-          <p>
-          e.g. <c>grep "Hello World!" first_program.txt</c> displays all the lines in the file <c>first_program.txt</c> that contain the text "Hello World!". 
-          </p>
-        </li>
-      </ul>
-    </p>
-    </li>
     </dl>
     </p>
  </paragraphs>

--- a/source/sec_dev_basic_shell_commands.ptx
+++ b/source/sec_dev_basic_shell_commands.ptx
@@ -625,10 +625,10 @@ And, if you respond with "n", then the removal will not happen.
     </p>
   <p>
   <p>
-  An additional efficiency-enhancing feature is the <em>history</em> command. This command conveniently presents a record of previously executed shell commands, enabling users to effortlessly revisit their command history. This proves highly beneficial by sparing users the effort of repeatedly consulting documentation for commands they intend to use. 
+  An additional efficiency-enhancing feature is the <term>history</term> command. This command conveniently presents a record of previously executed shell commands, enabling users to effortlessly revisit their command history. 
   </p>
   <p>
-  Here's an instance of what might be displayed when the <c>history</c> command is executed:
+  Here's an example of what might be displayed when the <c>history</c> command is executed:
   </p>
   <pre>
   1  git init

--- a/source/sec_dev_basic_shell_commands.ptx
+++ b/source/sec_dev_basic_shell_commands.ptx
@@ -624,7 +624,24 @@ And, if you respond with "n", then the removal will not happen.
     The <em>up arrow</em> key retrieves the previous shell command. If you press it multiple times, it will take you back through multiple commands in your shell history. This is a useful way to repeat a command. For example, if you had a typo, you can use the up arrow, edit the command, and push enter to fix the command. Analogously, the <em>down arrow</em> will move you in the reverse direction through the shell command history. For more useful shell commands, type <c>man bash</c> for hints on how to search your shell history, re-execute commands, and much more.
     </p>
   <p>
+  <p>
+  An additional efficiency-enhancing feature is the <em>history</em> command. This command conveniently presents a record of previously executed shell commands, enabling users to effortlessly revisit their command history. This proves highly beneficial by sparing users the effort of repeatedly consulting documentation for commands they intend to use. 
+  </p>
+  <p>
+  Here's an instance of what might be displayed when the <c>history</c> command is executed:
+  </p>
+  <pre>
+  1  git init
+  2  git add main.c
+  3  git commit -m "Initial commit"
+  4  git remote add origin https://github.com/username/repo.git
+  5  git push -u origin master
+  6  history
+  </pre>
+
+    <p>
     This paragraph is intended to alert you to some useful search features. A couple examples of very common search patterns are using wildcards for zero or more characters or for a single character.  The asterisk (*) specifies zero or more characters to match. In bash the question mark (?) is used for matching exactly one single character.
+    </p>
     <notation>
       <usage><m>*</m></usage>
       <description>asterisk - wildcard for zero or more characters</description>
@@ -664,8 +681,6 @@ rm: remove regular file 'newfile2_cp.txt'?
 <p>
 As you can see, these search patterns give you a lot of power and control. 
   </p>
-
-  
   </paragraphs>
 
 </subsection>


### PR DESCRIPTION
### Description
This PR enhances the **Bash Shell Cheat Sheet**  and **Basic Shell Commands** by adding the 'history' command.

### Testing
1. Navigate to Section 7 of the _Open Source_ textbook, where the **Bash Shell Cheat Sheet** is located.
2. Head to the **The Basics: Reading, Writing, Counting, etc.** section, where you should now find the 'history' command along with a clear and informative explanation.
3. Navigate to the **Basic Shell Commands** in Section 3.
4. Make sure you see the paragraph on history and that it is explained well.
---
| Bash Shell Cheat Sheet | Basic Shell Commands |
|----------------|-------------------|
| ![image](https://github.com/pearcej/opensource/assets/97637517/a0b30e12-b37c-4b52-9a22-449aa26f4d22) | ![image](https://github.com/pearcej/opensource/assets/97637517/e9c4c03a-4960-4da0-b94f-a75c30d43458) |

fixes #250 