### PR TITLE
Add logs/ to be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ ehthumbs_vista.db
 .Trash-*
 .nfs*
 
+# Don't track build logs
+logs/
+
 # Don't include VSCode generated files
 .vscode
 *.code-workspace


### PR DESCRIPTION
### Description
This PR is a simple one-line change that will make the development process mildly easier by making sure that Git does not track build files. 

### Testing
1. Build locally using the command: ` python3 -m pretext build web.`
2. Confirm that your build log remains accessible in the "logs/" directory.
3. Execute a `git status` command and verify that the "logs/" folder does not appear among the untracked items.

fixes #262 