### PR TITLE
Fix #265 by closing the image tag properly for git-head-to-master.png

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -128,7 +128,9 @@ $ git commit -m 'Initial commit'</pre><!--</div attr= class="content">--><!--</d
 <!-- div attr= class="content"-->
 <figure xml:id="git-HEAD-branch">
   <caption>HEAD pointing to a branch</caption>
-  <image source='git-head-to-master.png'/>
+  <image source='git-head-to-master.png'>
+   <description>Diagram showing the HEAD pointing to the 'master' branch and ultimately pointing at different commits.</description>
+  </image>
 </figure>
 <!--</div attr= class="content">-->
 


### PR DESCRIPTION
Related to the issue "Missing "alt" tag on image "git-head-to-master.png" in the Git Branching Chapter 4.4.5"