### PR TITLE
ADD term Fork from Section 4.6.1 to Text Index in Appendices

### DIFF
--- a/source/sec_git_github.ptx
+++ b/source/sec_git_github.ptx
@@ -39,6 +39,7 @@
 
 <!-- div attr= class="paragraph"-->
 				<p>
+				<idx>Fork</idx>
 					If you want to contribute to an existing project to which you don’t have write access (aka push access), you can <term>fork</term> the project. When you “fork” a project, GitHub will make a copy of the project that is entirely yours; it lives in your namespace, and you can push to it.
 				</p><!--</div attr= class="paragraph">-->
 


### PR DESCRIPTION
Section 4.6.1 Contributing to a Project, in Ch. 4.6 Github - Git in the Cloud, contains very important terms which relate to contributing to open source projects. Forking is a vital concept to understand in order to contribute well without causing conflicts or further issues on shared repositories. The Text Index in the back of the textbook was missing this term, but now will include it with a link to the section/paragraph referenced. 