### PR TITLE
Addition of "git commit --amend" command in Text Index of Appendices chapter

### DIFF
--- a/source/ap_git_cheat_sheet.ptx
+++ b/source/ap_git_cheat_sheet.ptx
@@ -78,6 +78,12 @@
           Commit all staged files to the local repository. For more detail see <url href="https://github.com/git-guides/git-commit" visual="github.com/git-guides/git-commit">Git Guides: Git Commit</url>
         </p>
       </li>
+      <li>
+          <title><c>git commit --amend</c></title>
+          <p>
+            modify the most recent commit by either updating its content or changing its commit message.
+          </p>
+        </li>
 
       <li>
         <title><c>git push</c></title>
@@ -149,6 +155,37 @@
           <title><c>git stash drop</c></title>
           <p>
             The <c>git stash drop</c> command deletes the most recent stashed work. 
+          </p>
+        </li>
+      </dl>
+    </subsection>
+
+
+    <subsection xml:id="a-git-restoring">
+      <title>Git Restoring/Reverting</title>
+      <dl width="narrow">
+        <li>
+          <title><c>git restore</c></title>
+          <p>
+            Provide a safer way to revert changes in the working tree or staging area. It's designed specifically for restoring files without switching branches or altering commit history.
+          </p>
+        </li>
+        <li>
+          <title><c>git reset</c></title>
+          <p>
+            Allows users to reset the current HEAD to a specified state, often used to unstage changes or modify the commit history. 
+          </p>
+        </li>
+        <li>
+          <title><c>git revert</c></title>
+          <p>
+            Create a new commit that undoes changes from a specified commit. This can be seen as a way to "restore" the state of the repository to a prior condition, but through a new commit. 
+          </p>
+        </li>
+        <li>
+          <title><c>git clean</c></title>
+          <p>
+            Remove untracked files from the working tree. It's similar in spirit to git restore in that it helps you bring your working directory to a clean state, but it's focused on untracked files.
           </p>
         </li>
       </dl>

--- a/source/sec_git_undoing.ptx
+++ b/source/sec_git_undoing.ptx
@@ -20,6 +20,7 @@
 <!-- div attr= class="content"-->
 			<pre>$ git commit --amend
       </pre><!--</div attr= class="content">--><!--</div attr= class="listingblock">-->
+	  <idx>git commit --amend</idx>
 
 <!-- div attr= class="paragraph"-->
 			<p>

--- a/source/sec_git_undoing.ptx
+++ b/source/sec_git_undoing.ptx
@@ -20,7 +20,6 @@
 <!-- div attr= class="content"-->
 			<pre>$ git commit --amend
       </pre><!--</div attr= class="content">--><!--</div attr= class="listingblock">-->
-	  <idx>git commit --amend</idx>
 
 <!-- div attr= class="paragraph"-->
 			<p>


### PR DESCRIPTION
Issue:
Normally, certain keywords are referred back in the Text Index section of the Appendices chapter. It is a valuable and convenient way to provide users of the Open Source book the opportunity to see definitions of keywords without having to look for chapters and sections. The Text Index section plays the role of a Thesaurus, where any user can look for words which are sorted in alphabetical order. However, some of the important terminologies of the section 4.5, namely "git commit --amend", were still not in the Text Index section.

Solution:
To add the "git commit --amend" section to the Text Index section, we just had to add a new add named <idx>"name of the section we want to add"</idx> below the tag that initiates that section in the pretext file "sec_git_undoing.ptx". In that case, when the pretext file is rendered, the keyword "git commit --amend" will be created, placed in the right alphabetical order, and it will refer to the section 4.5 of the book that gives a more explanatory approach of the term. 

Test:
After the initial setup and installation, one would have to not only look at the file "sec_git_undoing.ptx" to look for any flaw. Then, use the building and viewing command to open the book to your localhost inside your browser. There, you can direct yourself to the Text Index section and inspect the section "git commit --amend".