### PR TITLE
Add branch to index.

### DIFF
--- a/source/sec_git_branching.ptx
+++ b/source/sec_git_branching.ptx
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <section xml:id="sec_git_branching" xmlns:xi="http://www.w3.org/2001/XInclude">
+<idx><h>branch</h></idx>
   <title>Git Branching</title>
   <introduction>
+		
 		<p>
 			Nearly every VCS has some form of branching support. Branching means you diverge from the main line of development and continue to do work without messing with that main line. In many VCS tools, this is a somewhat expensive process, often requiring you to create a new copy of your source code directory, which can take a long time for large projects.
 		</p>
+		
 		<p>
 			Some people refer to Git’s branching model as its “killer feature,” and it certainly sets Git apart in the VCS community. Why is it so special? The way Git branches is incredibly lightweight, making branching operations nearly instantaneous, and switching back and forth between branches generally just as fast. Unlike many other VCSs, Git encourages workflows that branch and merge often, even multiple times in a day. Understanding and mastering this feature gives you a powerful and unique tool and can entirely change the way that you develop.
 		</p>
   </introduction>
+
 
 <subsection xml:id="_git_branches_overview">
 			<title>Branches in a Nutshell</title>
@@ -128,9 +132,7 @@ $ git commit -m 'Initial commit'</pre><!--</div attr= class="content">--><!--</d
 <!-- div attr= class="content"-->
 <figure xml:id="git-HEAD-branch">
   <caption>HEAD pointing to a branch</caption>
-  <image source='git-head-to-master.png'>
-   <description>Diagram showing the HEAD pointing to the 'master' branch and ultimately pointing at different commits.</description>
-  </image>
+  <image source='git-head-to-master.png'/>
 </figure>
 <!--</div attr= class="content">-->
 


### PR DESCRIPTION
Issue: 
There was no reference to branch in index even though it's an important concept in Open Source.

Fix:
Change sec_git_branching.ptx to add branch as an index in reference to first paragraph of section. 

Test: To test these changes, build the pretext book, view the changes and ensure that the reference to branch in the index references the first paragraph of the git branching section.

Fix #258