### PR TITLE
Issue272 freeware

### DIFF
--- a/source/sec_oss_share_code.ptx
+++ b/source/sec_oss_share_code.ptx
@@ -17,7 +17,7 @@
 		</p>
 
 		<p>
-			<idx>Freeware</idx>
+			<idx>freeware</idx>
 			Even freeware — programs that are downloadable for free from the internet — may not share their source code with the world. You can get the program for free, but if it breaks, or if you think of a way to make it better, there’s no good way to fix it if you don't have the source code. For example, you can get the Flash Player from Adobe for free, but if you find a bug that crashes Firefox, you’re stuck with that bug until Adobe fixes it.
 		</p>
 

--- a/source/sec_oss_share_code.ptx
+++ b/source/sec_oss_share_code.ptx
@@ -18,7 +18,7 @@
 
 		<p>
 			<idx>freeware</idx>
-			Even freeware — programs that are downloadable for free from the internet — may not share their source code with the world. You can get the program for free, but if it breaks, or if you think of a way to make it better, there’s no good way to fix it if you don't have the source code. For example, you can get the Flash Player from Adobe for free, but if you find a bug that crashes Firefox, you’re stuck with that bug until Adobe fixes it.
+			Even <term>freeware</term> — programs that are downloadable for free from the internet — may not share their source code with the world. You can get the program for free, but if it breaks, or if you think of a way to make it better, there’s no good way to fix it if you don't have the source code. For example, you can get the Flash Player from Adobe for free, but if you find a bug that crashes Firefox, you’re stuck with that bug until Adobe fixes it.
 		</p>
 
 		<p>

--- a/source/sec_oss_share_code.ptx
+++ b/source/sec_oss_share_code.ptx
@@ -17,6 +17,7 @@
 		</p>
 
 		<p>
+			<idx>Freeware</idx>
 			Even freeware — programs that are downloadable for free from the internet — may not share their source code with the world. You can get the program for free, but if it breaks, or if you think of a way to make it better, there’s no good way to fix it if you don't have the source code. For example, you can get the Flash Player from Adobe for free, but if you find a bug that crashes Firefox, you’re stuck with that bug until Adobe fixes it.
 		</p>
 


### PR DESCRIPTION
Did: 

added a <idx> tag to add freeware as a term to the index. 

To test:
-navigate to the index page
-locate freeware, and click on the Paragraph next to the word
-click in-context and see if it goes to the second paragraph of 1.4.1, it should highlight that second paragraph


fix issue 272