### PR TITLE
Fix typo in 6.2.1 issue301

### DIFF
--- a/source/sec_docu_involvement.ptx
+++ b/source/sec_docu_involvement.ptx
@@ -25,7 +25,7 @@
 			<p><ol>
 
 				<li>
-				Developers often don't like technical writing for think that writing is not a principal skill.
+				Developers often don't like technical writing or think that writing is not a principal skill.
 				</li>
 
 


### PR DESCRIPTION
Issue:
There was a typo in section 6.2.1 where the word "for" was used instead of "or".

Fix:
I changed the word from "for" to "or".

Test:
This issue was tested by running pretext build web, followed by pretext view web to ensure proper rendering.

Fix #301 