### PR TITLE
Issue #201 fix

### DIFF
--- a/source/sec_git_basics.ptx
+++ b/source/sec_git_basics.ptx
@@ -458,7 +458,7 @@ M  lib/simplegit.rb
 
 <!-- div attr= class="paragraph"-->
 				<p>
-					Glob patterns are like simplified regular expressions that shells use. An asterisk (<c>*</c>) matches zero or more characters; <c>[abc]</c> matches any character inside the brackets (in this case a, b, or c); a question mark (<c>?</c>) matches a single character; and brackets enclosing characters separated by a hyphen (<c>[0-9]</c>) matches any character between them (in this case 0 through 9). You can also use two asterisks to match nested directories; <c>a/**/z</c> would match <c>a/z</c>, <c>a/b/z</c>, <c>a/b/c/z</c>, and so on.
+					Glob patterns are like simplified regular expressions that shells use. An asterisk (<c>*</c>) matches zero or more characters; <c>[abc]</c> matches any character inside the brackets (in this case a, b, or c); a question mark (<c>?</c>) matches a single character; and brackets enclosing characters separated by a hyphen (<c>[0-9]</c>) matches any character between them (in this case 0 through 9).
 					<notation>
 						<usage><m>[ - ]</m></usage>
 						<description>brackets - encloses characters</description>
@@ -468,6 +468,13 @@ M  lib/simplegit.rb
 						<description>asterisk - matches zero or more characters</description>
 					</notation>
 				</p><!--</div attr= class="paragraph">-->
+				<p>
+					You can also use two asterisks to match nested directories; <c>a/**/z</c> would match <c>a/z</c>, <c>a/b/z</c>, <c>a/b/c/z</c>, and so on.
+					<notation>
+						<usage><m>**</m></usage>
+						<description>double asterisk - matches nested directories</description>
+					</notation>
+				</p>
 
 <!-- div attr= class="paragraph"-->
 				<p>


### PR DESCRIPTION
separated double asterisk into its own paragraph and added appropriate <notation>, <usage>, <m>, and <description> tags so that the double asterisk appears separately in the index. Fixes issue #201.