### PR TITLE
FIXES Issue #368: prefer typo

### DIFF
--- a/source/sec_docu_scope.ptx
+++ b/source/sec_docu_scope.ptx
@@ -44,7 +44,7 @@
 		</p>
 
 		<p>
-			Correcting documentation is often one of the first contributions that new contributors make to a project. This is because it is often the easiest way to get started. According to Mozilla, potential contributors prefer preferred simpler tasks to more challenging tasks, and shorter tasks to long tasks.
+			Correcting documentation is often one of the first contributions that new contributors make to a project. This is because it is often the easiest way to get started. According to Mozilla, potential contributors prefer simpler tasks to more challenging tasks, and shorter tasks to long tasks.
 			They found when given simpler choices, the percentage of people who engaged with the Mozilla contribution page by either choosing a contribution task or selecting not-ready was 60%, much higher than the 15% engagement rate the page had seen before they began looking into potential contributor preferences. See <url href="https://blog.mozilla.org/community/2015/09/01/participation-lab-notes-short-simple-tasks-increase-engagement/" visual="blog.mozilla.org/community/2015/09/01/participation-lab-notes-short-simple-tasks-increase-engagement/">Participation Lab Notes: Short Simple Tasks Increase Engagement</url> for more information.
 				
 		</p>


### PR DESCRIPTION
##Description
Removes "preferred" from the paragraph.

fixes Issue #368 

Before:
<img width="929" height="370" alt="image" src="https://github.com/user-attachments/assets/7cc7b6c0-836d-44f3-9207-b065cb2e847b" />


After:
<img width="867" height="350" alt="image" src="https://github.com/user-attachments/assets/4e84ec69-342d-4a95-95b7-696750db4125" />


Tested using web build

Reviewed by Hope Michael